### PR TITLE
feat: support paging proxying

### DIFF
--- a/server.go
+++ b/server.go
@@ -299,9 +299,23 @@ handler:
 				}
 				break handler
 			} else {
-				if err = sendPacket(conn, encodeSearchDone(messageID, LDAPResultSuccess)); err != nil {
-					log.Printf("sendPacket error %s", err.Error())
-					break handler
+				supportedControls := false
+				for _, control := range controls {
+					if control.GetControlType() == ControlTypePaging {
+						supportedControls = true
+						break
+					}
+				}
+				if supportedControls {
+					if err = sendPacket(conn, encodeSearchDoneWithControls(messageID, LDAPResultSuccess, controls)); err != nil {
+						log.Printf("sendPacket error %s", err.Error())
+						break handler
+					}
+				} else {
+					if err = sendPacket(conn, encodeSearchDone(messageID, LDAPResultSuccess)); err != nil {
+						log.Printf("sendPacket error %s", err.Error())
+						break handler
+					}
 				}
 			}
 		case ApplicationUnbindRequest:


### PR DESCRIPTION
Support for proxying paging requests.

When performing massive queries against the backend server, paging is now supported to allow the client and the backend to agree on chunk size, etc.

Testing: setup backend server, then query using for instance:
```
ldapsearch -LLL -H ldap://localhost:3893 -E pr=2/prompt\
    -D cn=admin,dc=glauth,dc=com -w password -x -bdc=glauth,dc=com \
    "(cn=*)"
```