### PR TITLE
Address panic when client starts a StartTLS connection but server is not configured to accept

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/glauth/ldap
 
 go 1.14
 
-require github.com/go-asn1-ber/asn1-ber v1.5.4
+require github.com/go-asn1-ber/asn1-ber v1.5.5

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/go-asn1-ber/asn1-ber v1.5.4 h1:vXT6d/FNDiELJnLb6hGNa309LMsrCoYFvpwHDF0+Y1A=
-github.com/go-asn1-ber/asn1-ber v1.5.4/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
+github.com/go-asn1-ber/asn1-ber v1.5.5 h1:MNHlNMBDgEKD4TcKr36vQN68BA00aDfjIt3/bD50WnA=
+github.com/go-asn1-ber/asn1-ber v1.5.5/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=

--- a/server.go
+++ b/server.go
@@ -324,7 +324,7 @@ handler:
 		case ApplicationExtendedRequest:
 			var tlsConn *tls.Conn
 			if n := len(req.Children); n == 1 || n == 2 {
-				if name := ber.DecodeString(req.Children[0].Data.Bytes()); name == oidStartTLS {
+				if name := ber.DecodeString(req.Children[0].Data.Bytes()); name == oidStartTLS && server.TLSConfig != nil {
 					tlsConn = tls.Server(conn, server.TLSConfig)
 				}
 			}


### PR DESCRIPTION
Addressing https://github.com/glauth/glauth/issues/389



- **fix: don't start TLS connection if TLSConfig is nil**

- **deps: update asn1-ber**


```
shipperizer in ~/shipperizer/ldap on master ● λ LDAPTLS_REQCERT=demand ldapsearch -LLL -H ldap://glauth.internal:3893 -D cn=serviceuser,ou=svcaccts,dc=glauth,dc=com  -w mysecret -x -bdc=glauth,dc=com cn=hackers -ZZ
ldap_start_tls: Protocol error (2)
	additional info: Protocol Error

```

## checks

- [x]  try a StartTLS setup and make sure all works fine as before (used https://github.com/shipperizer/glauth-demo/tree/tls/ldap, verified  that postgresql still works as expected)
- [x] replicate error conditions in [glauth/glauth/389 ](https://github.com/glauth/glauth/issues/389)